### PR TITLE
Generator: Consolidated options and moved parsing functions

### DIFF
--- a/generate_fpp.py
+++ b/generate_fpp.py
@@ -11,7 +11,7 @@ from lib.io_helpers import *
 
 from lib.tokens import lex
 from lib.name_visitor import AnnotatedName
-from lib.autograde import AutograderConfig, new_autograder_by_ext
+from lib.autograde import AutograderConfig, new_autograder_from_ext
 from lib.parse import parse_fpp_regions
 
 @dataclass
@@ -141,7 +141,7 @@ def generate_fpp_question(
     metadata["autograder"] = metadata.get("autograder", file_ext(source_path))
     options.update(**metadata)
 
-    autograder: AutograderConfig = new_autograder_by_ext(options.ag_extension)
+    autograder: AutograderConfig = new_autograder_from_ext(options.ag_extension)
 
     question_name = file_name(source_path)
 
@@ -160,22 +160,23 @@ def generate_fpp_question(
         print('- Copying {} to {} ...'.format(path.basename(source_path), copy_dest_path))
     copyfile(source_path, copy_dest_path)
 
+    setup_code = remove_region('setup_code', SETUP_CODE_DEFAULT)
+    answer_code = remove_region('answer_code')
+    server_code = remove_region('server')
+    prompt_code = remove_region('prompt_code')
+    question_text = remove_region('question_text')
+    
     if options.write_log:
         print('- Populating {} ...'.format(question_dir))
 
-    setup_code = remove_region('setup_code', SETUP_CODE_DEFAULT)
-    answer_code = remove_region('answer_code')
 
-    server_code = remove_region('server')
+
     gen_server_code, setup_names, answer_names = autograder.generate_server(
         setup_code=setup_code,
         answer_code=answer_code,
         no_ast=(not options.do_parse)
     )
     server_code = server_code or gen_server_code
-
-    prompt_code = remove_region('prompt_code')
-    question_text = remove_region('question_text')
 
     question_html = generate_question_html(
         prompt_code,

--- a/lib/autograde.py
+++ b/lib/autograde.py
@@ -45,7 +45,7 @@ def register_autograder(extension: str = ''):
         return cls
     return add_autograder
 
-def new_autograder_by_ext(extension: str) -> AutograderConfig:
+def new_autograder_from_ext(extension: str) -> AutograderConfig:
     if extension not in autograders:
         if extension in ("fpp", ''):
             Bcolors.warn('Autograder not specified! Add the "autograder" field ' + \

--- a/lib/autograde.py
+++ b/lib/autograde.py
@@ -36,10 +36,25 @@ class AutograderConfig(ABC):
 autograders: Dict[str, AutograderConfig] = {}
 
 def register_autograder(extension: str = ''):
+    with_dot = ('' if extension[0] == '.' else '.') + extension
+    without_dot = extension[1:] if extension[0] == '.' else extension
+
     def add_autograder(cls: AutograderConfig) -> AutograderConfig:
-        autograders.update({ extension : cls })
+        autograders.update({ with_dot : cls,
+                             without_dot : cls })
         return cls
     return add_autograder
+
+def new_autograder_by_ext(extension: str) -> AutograderConfig:
+    if extension not in autograders:
+        if extension in ("fpp", ''):
+            Bcolors.warn('Autograder not specified! Add the "autograder" field ' + \
+                        'to the metadata of the source file with the extension' + \
+                        ' of the autograder to use (e.g. "rb" for ruby)')
+        else:
+            Bcolors.warn(f"Autograder for extension '{extension}' not found!")
+        print("- Defaulting to Python autograder")
+    return autograders.get(extension, PythonAutograder)()
 
 @register_autograder(extension='.py')
 class PythonAutograder(AutograderConfig):

--- a/lib/parse.py
+++ b/lib/parse.py
@@ -1,0 +1,93 @@
+from typing import Dict
+from lib.tokens import Tokens, Token, TokenType, regex_chunk_lines
+from collections import defaultdict
+from enum import IntEnum
+from re import match as test
+from lib.consts import *
+import lib.io_helpers as io
+
+
+def parse_blanks(source_path: str, tkn: Token, blank_re: Pattern):
+    itr = regex_chunk_lines(blank_re, tkn.text, line_number=tkn.lineno)
+    # (exclusive) end of the last match
+    for line_number, found, chunk in itr:
+        if found:
+            # non-None
+            blank, = chunk.groups()
+            if not blank:
+                # only possible with custom regexes.
+                raise SyntaxError(
+                    'blankDelimiter Regex captured empty text at '
+                        + io.format_ln(source_path, line_number))
+
+            yield (blank, BLANK_SUBSTITUTE)
+        else:
+            yield (chunk, chunk)
+
+def parse_fpp_regions(tokens: Tokens) -> Dict[str, str]:
+    """Transform a lexed collection of Tokens into a dictionary where
+       keys are region names and values are data contained.
+    """
+    if 'blankDelimiter' in tokens.metadata:
+        blank_re = io.make_blank_re(tokens.metadata['blankDelimiter'])
+    else:
+        blank_re = DEFAULT_BLANK_PATTERN
+
+    r_texts: dict[str, list[str]] = defaultdict(list)
+    answer, prompt = r_texts['answer_code'], r_texts['prompt_code']
+
+    class DocstringState(IntEnum):
+        Accepting = 0
+        FollowWithNewline = 1
+        Finished = 2
+        Skipped = 3
+
+    docstring_state = DocstringState.Accepting
+    for tkn in tokens.data:
+        if not tkn.text: continue
+
+        if tkn.region:
+            if tkn.region == 'question_text' and docstring_state == DocstringState.FollowWithNewline:
+                r_texts[tkn.region].append('\n')
+                docstring_state = DocstringState.Finished
+            r_texts[tkn.region].append(tkn.text)
+            continue
+
+        if tkn.type == TokenType.DOCSTRING:
+            if docstring_state == DocstringState.Accepting:
+                qs = r_texts['question_text']
+                if qs:
+                    qs.append('\n')
+                    docstring_state = DocstringState.Finished
+                else:
+                    docstring_state = DocstringState.FollowWithNewline
+                qs.append(tkn.text[3:-3])
+            else:
+                prompt.append(tkn.text)
+                answer.append(tkn.text)
+        elif tkn.type == TokenType.COMMENT:
+            target = prompt if test(SPECIAL_COMMENT_PATTERN, tkn.text) \
+                else answer
+            target.append(tkn.text)
+        elif tkn.type == TokenType.STRING:
+            prompt.append(tkn.text)
+            answer.append(tkn.text)
+        elif tkn.type == TokenType.UNMATCHED:
+            for ans, prmpt in parse_blanks(tokens.source_path, tkn, blank_re):
+                answer.append(ans)
+                prompt.append(prmpt)
+        else:
+            raise Exception("Unreachable! Inexhaustive token types: " + str(tkn.type))
+
+        docstring_state = docstring_state or DocstringState.Skipped
+
+    out = { 'metadata': tokens.metadata }
+    for k, region_list in r_texts.items():
+        ls = ''.join(region_list)
+        ls = map(str.rstrip, ls.splitlines())
+        if k == 'prompt_code':
+            ls = filter(bool, ls)
+        out[k] = '\n'.join(ls).strip()
+
+    return out
+


### PR DESCRIPTION
Slight refactoring for the generator with two main contributions:
- Arguments passed through the CLI are now consolidated with those passed through the `metadata` region into an `Options` dataclass
- the `parse_` functions in `generate_fpp.py` have been moved to a separate file in `lib/` for readability