### PR TITLE
11 escape quotation marks when rendering template

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN wget https://github.com/ace-lab/pl-ucb-csxxx/archive/b9ddf6afc0ba654844ca8cf
 RUN unzip b9ddf6afc0ba654844ca8cf7019ae5e586e933cc
 RUN mv pl-ucb-csxxx-b9ddf6afc0ba654844ca8cf7019ae5e586e933cc/ /pl-ucb-csxxx/
 RUN rm b9ddf6afc0ba654844ca8cf7019ae5e586e933cc.zip
-RUN chown codespace /pl-ucb-csxxx
+RUN chown -R codespace /pl-ucb-csxxx
 
 # replace the element in the example course with the current version of the repo
 RUN rm -rf /pl-ucb-csxxx/elements/pl-faded-parsons/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,12 @@
     "name": "csxxx-fpp-devcontainer",
 	"build": { "dockerfile": "Dockerfile" },
 	"workspaceFolder": "/pl-ucb-csxxx",
-    
+
     "postCreateCommand": "sudo rm -rf /pl-ucb-csxx/elements/pl-faded-parsons; sudo cp -r /workspaces/pl-faded-parsons/ /pl-ucb-csxxx/elements/pl-faded-parsons/ && sudo chown -R codespace /pl-ucb-csxxx/elements/pl-faded-parsons/ && git config --global --add safe.directory /pl-ucb-csxxx/elements/pl-faded-parsons",
     "postAttachCommand" : "export HOST_JOBS_DIR=/tmp/pl_jobqueue && sudo docker run -it --rm -p 3000:3000 -v $HOST_JOBS_DIR:/jobs -v /pl-ucb-csxxx/:/course -v /var/run/docker.sock:/var/run/docker.sock prairielearn/prairielearn:latest",
-    
+    // This command runs the current deployment at Berkeley
+    // "postAttachCommand" : "export HOST_JOBS_DIR=/tmp/pl_jobqueue && sudo docker run -it --rm -p 4000:3000 -v $HOST_JOBS_DIR:/jobs -v /pl-ucb-csxxx/:/course -v /var/run/docker.sock:/var/run/docker.sock ucbcbt/ucb-prairielearn:latest",
+
     "features": {
         "ghcr.io/devcontainers/features/python:1": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}

--- a/pl-faded-parsons-code-line.mustache
+++ b/pl-faded-parsons-code-line.mustache
@@ -1,1 +1,1 @@
-<li class="prettyprint {{language}} ui-sortable-handle" style="margin-left: {{indent}}ch;">{{#segments}}{{#code}}{{content}}{{/code}}{{#blank}}<input type="text" style="width: {{width}}ch;" class="text-box parsons-blank" value="{{default}}" .="">{{/blank}}{{/segments}}</li>
+<li class="ui-sortable-handle" style="margin-left: {{indent}}ch;">{{#segments}}{{#code}}<code class="prettyprint lang-{{language}}">{{content}}</code>{{/code}}{{#blank}}<input type="text" style="width: {{width}}ch;" class="text-box parsons-blank" value="{{default}}" .="">{{/blank}}{{/segments}}</li>

--- a/pl-faded-parsons.css
+++ b/pl-faded-parsons.css
@@ -148,3 +148,7 @@ li.correctPosition, .testcase.pass {
 .text-box:focus{
     outline:0;
 }
+
+code {
+    font-size: 100%;
+}


### PR DESCRIPTION
Minor fix to get codespace working and what seems to be resolution of #11 

The issue was that the [code formatter](https://github.com/googlearchive/code-prettify) formatted the contents of the blanks that the student would provide, effectively introducing `>` symbols into the raw html and thus allowing arbitrary html injection. 

The fix was to prevent the formatter from looking at the `<input>` tags and instead wrap the static code in `<code>` tags and point the formatter only to those.