### PR TITLE
43 add visual indent option in no code layout

### DIFF
--- a/.devcontainer/csxxx-example/devcontainer.json
+++ b/.devcontainer/csxxx-example/devcontainer.json
@@ -1,18 +1,25 @@
 {
-  "name": "Produce workable ",
+  "name": "Edit: Course, Web View: Course",
   "build": { "dockerfile": "Dockerfile" },
   "workspaceFolder": "/pl-ucb-csxxx",
 
   "postCreateCommand": "sudo rm -rf /pl-ucb-csxx/elements/pl-faded-parsons; sudo cp -r /workspaces/pl-faded-parsons/ /pl-ucb-csxxx/elements/pl-faded-parsons/ && sudo chown -R codespace /pl-ucb-csxxx/elements/pl-faded-parsons/ && git config --global --add safe.directory /pl-ucb-csxxx/elements/pl-faded-parsons",
   "postAttachCommand": "export HOST_JOBS_DIR=/tmp/pl_jobqueue && sudo docker run -it --rm -p 3000:3000 -v $HOST_JOBS_DIR:/jobs -v /pl-ucb-csxxx/:/course -v /var/run/docker.sock:/var/run/docker.sock prairielearn/prairielearn:latest",
-  // This command runs the current deployment at Berkeley
-  // "postAttachCommand" : "export HOST_JOBS_DIR=/tmp/pl_jobqueue && sudo docker run -it --rm -p 4000:3000 -v $HOST_JOBS_DIR:/jobs -v /pl-ucb-csxxx/:/course -v /var/run/docker.sock:/var/run/docker.sock ucbcbt/ucb-prairielearn:latest",
 
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "version" : "3.10"
     },
-    // "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
-  }
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+  },
+
+  "customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"esbenp.prettier-vscode",
+				"dawhite.mustache"
+			]
+		}
+	}
 }

--- a/.devcontainer/edit-element/devcontainer.json
+++ b/.devcontainer/edit-element/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/universal
 {
-	"name": "View element in course",
+	"name": "Edit: Element, Web View: Course",
 
     "dockerComposeFile": [ "docker-compose.yml" ],
     "service" : "devcontainer",

--- a/.devcontainer/raw-element/devcontainer.json
+++ b/.devcontainer/raw-element/devcontainer.json
@@ -1,10 +1,8 @@
 {
-    "name": "raw-element-devcontainer",
+    "name": "Edit: Element, Web View: None",
     "image" : "mcr.microsoft.com/vscode/devcontainers/universal:latest",
 
     "features": {
-        "ghcr.io/devcontainers/features/python:1": {},
-        // "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-        // "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+        "ghcr.io/devcontainers/features/python:1": {}
     }
 }

--- a/pl-faded-parsons-question.mustache
+++ b/pl-faded-parsons-question.mustache
@@ -30,7 +30,7 @@
         <pre class="prettyprint" language="{{{language}}}"> {{{text}}} </pre>
         {{/pre_text}}
         {{#given}}
-        <div id="solution-{{uuid}}" class="solution-code-tray codeline-tray soft-border col-sm-{{#narrow}}6{{/narrow}}{{#wide}}12{{/wide}} {{^wide}}px-1{{/wide}}">
+        <div id="solution-{{uuid}}" style="margin-left:{{visual_indent}}ch" class="solution-code-tray codeline-tray soft-border col-sm-{{#narrow}}6{{/narrow}}{{#wide}}12{{/wide}} {{^wide}}px-1{{/wide}}">
             <ol id="ol-solution-{{uuid}}" class="ui-sortable codeline-list output">
                 {{#lines}}
                     {{> pl-faded-parsons-code-line}}

--- a/pl-faded-parsons.py
+++ b/pl-faded-parsons.py
@@ -198,8 +198,9 @@ def render_question_panel(element_html, data):
         if format in ("no_code", ):
             random.shuffle(solution_lines)
 
+    visual_indent = pl.get_string_attrib(element, "visual-indent", 0)
     scrambled = { "lines" : scrambled_lines, "answers_name" : answers_name }
-    given     = { "lines" : solution_lines , "answers_name" : answers_name }
+    given     = { "lines" : solution_lines , "answers_name" : answers_name, "visual_indent" : visual_indent }
 
     if format == "right":
         if pre_text or post_text:

--- a/pl-faded-parsons.py
+++ b/pl-faded-parsons.py
@@ -199,6 +199,10 @@ def render_question_panel(element_html, data):
             random.shuffle(solution_lines)
 
     visual_indent = pl.get_string_attrib(element, "visual-indent", 0)
+
+    if visual_indent is not None and format == "no_code":
+        raise ValueError(f"Cannot have a non-zero visual indent for format `{format}`! Accepted format(s): no-code")
+
     scrambled = { "lines" : scrambled_lines, "answers_name" : answers_name }
     given     = { "lines" : solution_lines , "answers_name" : answers_name, "visual_indent" : visual_indent }
 


### PR DESCRIPTION
Changes:
* add `visual-indent` optional attribute to the element
  * This sets a newly added explicit `style` attribute on the submission box div
  * If this is specified with a format other than "no-code", an exception is raised
* Renamed all devcontainers for clarity and removed commented fields