### PR TITLE
Major Update to the Python Backend

### DIFF
--- a/pl-faded-parsons-answer.mustache
+++ b/pl-faded-parsons-answer.mustache
@@ -4,11 +4,3 @@
   <pl-code language="python" source-file-name={{solution_path}}>
   </pl-code>
 </div>
-{{#notes}}
-<div class="border">
-  <h4>Notes regarding the solution:</h4>
-  <div>
-    {{notes}}
-  </div>
-</div>
-{{/notes}}

--- a/pl-faded-parsons-question.mustache
+++ b/pl-faded-parsons-question.mustache
@@ -72,10 +72,10 @@
 
                 solution: '#solution-{{uuid}}',
                 solutionList: '#ol-solution-{{uuid}}',
-                {{#scrambled}}
+                {{#starter}}
                 starter: '#starter-code-{{uuid}}',
                 starterList: '#ol-starter-code-{{uuid}}',
-                {{/scrambled}}
+                {{/starter}}
             })
         )
     );

--- a/pl-faded-parsons-question.mustache
+++ b/pl-faded-parsons-question.mustache
@@ -8,8 +8,8 @@
 {{! if vertical (or no-code), full size boxes }}
 <div id="pl-faded-parsons-{{uuid}}" role="application" class="col fpp-global-defs pl-faded-parsons soft-border" language="{{language}}">
     {{! form field to be filled with order to save the current submission }}
-    <input class="main" name="{{answers-name}}.main" type="hidden" value=""/>
-    <input class="log" name="{{answers-name}}.log" type="hidden" value="{{previous-log}}" />
+    <input class="main" name="{{answers_name}}.main" type="hidden" value=""/>
+    <input class="log" name="{{answers_name}}.log" type="hidden" value="{{previous_log}}" />
 
     <div class="row" style="margin:0px">
         {{! note: by entering the {#starter} {/starter} section, the mustache renderer dereferences
@@ -25,7 +25,7 @@
         </div>
         {{/starter}}
         {{#pre_text}}
-        <pre class="prettyprint" language="{{language}}"> {{{text}}} </pre>
+        <pre class="prettyprint" language="{{language}}">{{{text}}}</pre>
         {{/pre_text}}
         {{#given}}
         <div id="solution-{{uuid}}" class="solution-code-tray codeline-tray soft-border col-sm-{{#narrow}}6{{/narrow}}{{#wide}}12{{/wide}} {{^wide}}px-1{{/wide}}">

--- a/pl-faded-parsons-question.mustache
+++ b/pl-faded-parsons-question.mustache
@@ -6,18 +6,16 @@
 
 {{! if not vertical (horizontal), keep half size boxes }}
 {{! if vertical (or no-code), full size boxes }}
-<div id="pl-faded-parsons-{{uuid}}" role="application" class="col fpp-global-defs pl-faded-parsons soft-border" language="{{{language}}}">
+<div id="pl-faded-parsons-{{uuid}}" role="application" class="col fpp-global-defs pl-faded-parsons soft-border" language="{{language}}">
     {{! form field to be filled with order to save the current submission }}
-    <input class="starter-tray-order" name="{{answers-name}}starter-tray-order" type="hidden" value=""/>
-    <input class="solution-tray-order" name="{{answers-name}}solution-tray-order" type="hidden" value=""/>
-    <input class="student-parsons-solution" name="{{answers-name}}student-parsons-solution" type="hidden" value=""/>
-    <input class="log" name="{{answers-name}}log" type="hidden" value="{{previous_log}}" />
+    <input class="main" name="{{answers-name}}.main" type="hidden" value=""/>
+    <input class="log" name="{{answers-name}}.log" type="hidden" value="{{previous-log}}" />
 
     <div class="row" style="margin:0px">
-        {{! note: by entering the {#scrambled} {/scrambled} section, the mustache renderer dereferences
-              all tags as children of the `scrambled` node, which has a duplicate of the
+        {{! note: by entering the {#starter} {/starter} section, the mustache renderer dereferences
+              all tags as children of the `starter` node, which has a duplicate of the
               `answers_name` data dereferenced elsewhere }}
-        {{#scrambled}}
+        {{#starter}}
         <div id="starter-code-{{uuid}}" class="starter-code-tray codeline-tray soft-border col-sm-{{#narrow}}6{{/narrow}}{{#wide}}12{{/wide}} px-1">
             <ol id="ol-starter-code-{{uuid}}" class="ui-sortable codeline-list">
                 {{#lines}}
@@ -25,9 +23,9 @@
                 {{/lines}}
             </ol>
         </div>
-        {{/scrambled}}
+        {{/starter}}
         {{#pre_text}}
-        <pre class="prettyprint" language="{{{language}}}"> {{{text}}} </pre>
+        <pre class="prettyprint" language="{{language}}"> {{{text}}} </pre>
         {{/pre_text}}
         {{#given}}
         <div id="solution-{{uuid}}" class="solution-code-tray codeline-tray soft-border col-sm-{{#narrow}}6{{/narrow}}{{#wide}}12{{/wide}} {{^wide}}px-1{{/wide}}">
@@ -39,7 +37,7 @@
         </div>
         {{/given}}
         {{#post_text}}
-        <pre class="prettyprint" language="{{{language}}}"> {{{text}}} </pre>
+        <pre class="prettyprint" language="{{language}}"> {{{text}}} </pre>
         {{/post_text}}
     </div>
 
@@ -65,19 +63,19 @@
                 main: '#pl-faded-parsons-{{uuid}}',
                 uuid: '{{uuid}}',
 
+                logStorage: "#pl-faded-parsons-{{uuid}} > input.log",
+                storage: "#pl-faded-parsons-{{uuid}} > input.main",
+
                 ariaDescriptor: "#pl-faded-parsons-aria-descriptor-{{uuid}}",
                 ariaDetails: "#pl-faded-parsons-aria-details-{{uuid}}",
+                toolbar: "#widget-toolbar-{{uuid}}",
+
                 solution: '#solution-{{uuid}}',
                 solutionList: '#ol-solution-{{uuid}}',
-                solutionOrderStorage: "#pl-faded-parsons-{{uuid}} > input.solution-tray-order",
-                solutionSubmissionStorage: "#pl-faded-parsons-{{uuid}} > input.student-parsons-solution",
                 {{#scrambled}}
                 starter: '#starter-code-{{uuid}}',
                 starterList: '#ol-starter-code-{{uuid}}',
                 {{/scrambled}}
-                starterOrderStorage: "#pl-faded-parsons-{{uuid}} > input.starter-tray-order",
-                logStorage: "#pl-faded-parsons-{{uuid}} > input.log",
-                toolbar: "#widget-toolbar-{{uuid}}",
             })
         )
     );

--- a/pl-faded-parsons.py
+++ b/pl-faded-parsons.py
@@ -310,16 +310,16 @@ def render_question_panel(element, data):
     # chevron skips rendering when values are falsy (eg pre-text/post-text/starter)
     html_params = {
         # main element config
-        "answers-name": answers_name,
+        "answers_name": answers_name,
         "language": lang,
-        "previous-log" : json.dumps(prev_submission.log),
+        "previous_log" : json.dumps(prev_submission.log),
         "uuid": pl.get_uuid(),
 
         # trays and code context
         "starter": use_starter_tray and tray_lines_to_mustache(state.starter),
-        "pre-text": pre_text,
+        "pre_text": pre_text,
         "given": tray_lines_to_mustache(state.solution),
-        "post-text": post_text,
+        "post_text": post_text,
     }
 
     with open('pl-faded-parsons-question.mustache', 'r') as f:
@@ -359,7 +359,7 @@ def render(element_html, data):
     pl.check_attribs(
         element,
         required_attribs=["answers-name"],
-        optional_attribs=["format", "language"],
+        optional_attribs=["format", "language", "file-name"],
     )
 
     panel_type = data['panel']


### PR DESCRIPTION
This started by trying to tackle #36 (which this will close), but it quickly became apparent that the old way of transmitting data from the JS to Python and back again was too brittle. The changes made in this PR do four things

1. Formalizes the schema that is used to communicate between python, mustache, and js with `dataclass`es and docstrings. The docstrings for the classes point to where the schemas originated.
2. Introduces `_import`/`_export` methods for use with pl-faded-parsons.js, and `to_mustache` for use with mustache.
3. Sets an extensible standard for communicating with pl-faded-parsons.js - namely: the `input.main` element will be a json store for all submission-data transmission, and `input.log` will be used for transmitting data for research purposes.
4. Break everything, probably. This needs lots of testing before merging.